### PR TITLE
Add multi-agent scraping scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,47 @@
+# Multi-Agent Scraping Scaffold
 
+This repository provides a minimal scaffold for a multi-agent web scraping
+solution with a Python backend and React frontend.
+
+## Backend
+
+The backend lives in the `backend/` directory and contains simple agents:
+
+- **controller.py** – orchestrates the workflow
+- **nlp_agent.py** – parses natural language instructions
+- **site_analyzer.py** – checks `robots.txt` and determines URLs
+- **scraper.py** – fetches pages and extracts data
+- **data_normalizer.py** – cleans scraped data
+- **storage_manager.py** – stores items in a SQLite database
+- **main.py** – FastAPI server exposing a `/run_job` endpoint
+
+Install dependencies and run the API:
+
+```bash
+pip install fastapi uvicorn requests beautifulsoup4
+uvicorn backend.main:app --reload
+```
+
+## Frontend
+
+A minimal React interface is provided in the `frontend/` directory.
+It contains `public/index.html` and `src/` React components. Use any
+static server to host it:
+
+```bash
+cd frontend
+npm install
+npm start
+```
+
+The frontend posts the user's prompt to the backend and displays how many
+items were scraped.
+
+## Usage
+
+1. Start the backend API.
+2. Serve the frontend.
+3. Enter a natural-language instruction in the textarea and run the job.
+
+This scaffold is intentionally lightweight so you can extend each agent as
+needed for your project.

--- a/backend/controller.py
+++ b/backend/controller.py
@@ -1,0 +1,16 @@
+"""Main controller that orchestrates the scraping workflow."""
+
+from nlp_agent import parse_instruction
+from site_analyzer import analyze_site
+from scraper import scrape_pages
+from data_normalizer import normalize_data
+from storage_manager import store_items
+
+
+def run_job(prompt: str) -> int:
+    task = parse_instruction(prompt)
+    urls = analyze_site(task["target"])
+    raw_items = scrape_pages(urls, task)
+    cleaned_items = [normalize_data(item) for item in raw_items]
+    store_items(cleaned_items)
+    return len(cleaned_items)

--- a/backend/data_normalizer.py
+++ b/backend/data_normalizer.py
@@ -1,0 +1,13 @@
+"""Utility functions to clean and normalize scraped data."""
+
+
+def normalize_data(item: dict) -> dict:
+    cleaned = {}
+    for key, value in item.items():
+        if key == "price" and value:
+            cleaned[key] = float(str(value).replace("$", "").replace(",", ""))
+        elif isinstance(value, str):
+            cleaned[key] = value.strip()
+        else:
+            cleaned[key] = value
+    return cleaned

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,21 @@
+"""FastAPI entrypoint."""
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+from controller import run_job
+
+app = FastAPI()
+
+
+n_workers = 0
+
+
+class JobRequest(BaseModel):
+    prompt: str
+
+
+@app.post("/run_job")
+async def run_job_endpoint(req: JobRequest) -> dict:
+    count = run_job(req.prompt)
+    return {"count": count}

--- a/backend/nlp_agent.py
+++ b/backend/nlp_agent.py
@@ -1,0 +1,10 @@
+"""NLP agent that parses natural language instructions."""
+
+def parse_instruction(prompt: str) -> dict:
+    """Convert a natural-language prompt into a structured task."""
+    # TODO: Replace with real NLP parsing
+    return {
+        "target": "https://example.com",
+        "fields": ["title", "price"],
+        "depth": 1,
+    }

--- a/backend/scraper.py
+++ b/backend/scraper.py
@@ -1,0 +1,22 @@
+"""Scraper agent for fetching and parsing pages."""
+
+import requests
+from bs4 import BeautifulSoup
+
+
+def scrape_pages(urls: list[str], task: dict) -> list[dict]:
+    items: list[dict] = []
+    for url in urls:
+        response = requests.get(url, timeout=10)
+        response.raise_for_status()
+        soup = BeautifulSoup(response.text, "html.parser")
+        item = {field: extract_field(soup, field) for field in task.get("fields", [])}
+        items.append(item)
+    return items
+
+
+def extract_field(soup: BeautifulSoup, field: str):
+    if field == "title":
+        return soup.title.string.strip() if soup.title else None
+    # Add more field handlers here
+    return None

--- a/backend/site_analyzer.py
+++ b/backend/site_analyzer.py
@@ -1,0 +1,16 @@
+"""Analyze target sites and produce URLs to scrape."""
+
+import urllib.robotparser
+from urllib.parse import urljoin
+
+
+def analyze_site(base_url: str) -> list[str]:
+    """Return a list of allowed URLs based on robots.txt."""
+    rp = urllib.robotparser.RobotFileParser()
+    rp.set_url(urljoin(base_url, "robots.txt"))
+    rp.read()
+
+    if not rp.can_fetch("*", base_url):
+        raise ValueError("Scraping disallowed by robots.txt")
+
+    return [base_url]

--- a/backend/storage_manager.py
+++ b/backend/storage_manager.py
@@ -1,0 +1,26 @@
+"""Storage manager for persisting scraped data."""
+
+import sqlite3
+
+DB_PATH = "data.sqlite3"
+
+
+def store_items(items: list[dict]) -> None:
+    conn = sqlite3.connect(DB_PATH)
+    cur = conn.cursor()
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS scraped_data (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            title TEXT,
+            price REAL
+        )
+        """
+    )
+    for item in items:
+        cur.execute(
+            "INSERT INTO scraped_data (title, price) VALUES (?, ?)",
+            (item.get("title"), item.get("price")),
+        )
+    conn.commit()
+    conn.close()

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "scraper-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "scripts": {
+    "start": "npx serve -s public"
+  }
+}

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Scraper Frontend</title>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="module" src="/src/index.js"></script>
+</body>
+</html>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,25 @@
+import { useState } from 'react';
+
+export default function App() {
+  const [prompt, setPrompt] = useState('');
+  const [status, setStatus] = useState('');
+
+  const handleSubmit = async () => {
+    setStatus('Running...');
+    const res = await fetch('/run_job', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ prompt }),
+    });
+    const data = await res.json();
+    setStatus(`Completed: ${data.count} items scraped`);
+  };
+
+  return (
+    <div>
+      <textarea value={prompt} onChange={(e) => setPrompt(e.target.value)} />
+      <button onClick={handleSubmit}>Run</button>
+      <p>{status}</p>
+    </div>
+  );
+}

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,0 +1,6 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App.jsx';
+
+const root = createRoot(document.getElementById('root'));
+root.render(<App />);


### PR DESCRIPTION
## Summary
- initialize backend and frontend folders
- implement basic agents for scraping and storage in Python
- add FastAPI server and simple React UI
- document usage in README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_688991ecb438833288138116c0d4ce9b