### PR TITLE
Fix cross-origin issues and build step

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The backend lives in the `backend/` directory and contains simple agents:
 - **storage_manager.py** – stores items in a SQLite database
 - **main.py** – FastAPI server exposing a `/run_job` endpoint
 
-Install dependencies and run the API:
+Install dependencies and run the API (CORS middleware is enabled by default):
 
 ```bash
 pip install fastapi uvicorn requests beautifulsoup4
@@ -25,8 +25,8 @@ uvicorn backend.main:app --reload
 ## Frontend
 
 A minimal React interface is provided in the `frontend/` directory.
-It contains `public/index.html` and `src/` React components. Use any
-static server to host it:
+The app is bundled with `esbuild` before serving so the browser can
+load the React modules:
 
 ```bash
 cd frontend

--- a/backend/controller.py
+++ b/backend/controller.py
@@ -1,10 +1,10 @@
 """Main controller that orchestrates the scraping workflow."""
 
-from nlp_agent import parse_instruction
-from site_analyzer import analyze_site
-from scraper import scrape_pages
-from data_normalizer import normalize_data
-from storage_manager import store_items
+from .nlp_agent import parse_instruction
+from .site_analyzer import analyze_site
+from .scraper import scrape_pages
+from .data_normalizer import normalize_data
+from .storage_manager import store_items
 
 
 def run_job(prompt: str) -> int:

--- a/backend/main.py
+++ b/backend/main.py
@@ -3,9 +3,18 @@
 from fastapi import FastAPI
 from pydantic import BaseModel
 
-from controller import run_job
+from .controller import run_job
+
+from fastapi.middleware.cors import CORSMiddleware
 
 app = FastAPI()
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 
 n_workers = 0

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,11 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },
+  "devDependencies": {
+    "esbuild": "^0.20.0"
+  },
   "scripts": {
-    "start": "npx serve -s public"
+    "build": "npx esbuild src/index.js --bundle --outfile=public/app.js --format=esm --loader:.js=jsx",
+    "start": "npm run build && npx serve -s public"
   }
 }

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -8,6 +8,6 @@
 </head>
 <body>
   <div id="root"></div>
-  <script type="module" src="/src/index.js"></script>
+  <script type="module" src="/app.js"></script>
 </body>
 </html>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,7 +6,7 @@ export default function App() {
 
   const handleSubmit = async () => {
     setStatus('Running...');
-    const res = await fetch('/run_job', {
+    const res = await fetch('http://localhost:8000/run_job', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ prompt }),


### PR DESCRIPTION
## Summary
- allow CORS in FastAPI app
- use package-relative imports in backend
- bundle React app with esbuild before serving
- call backend with explicit URL

## Testing
- `python -m py_compile backend/*.py`
- `npm run build --silent`

------
https://chatgpt.com/codex/tasks/task_e_68899667d78883328d263084f094ce7a