### PR TITLE
Add data preview & CSV export

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The backend lives in the `backend/` directory and contains simple agents:
 - **scraper.py** – fetches pages and extracts data
 - **data_normalizer.py** – cleans scraped data
 - **storage_manager.py** – stores items in a SQLite database
-- **main.py** – FastAPI server exposing a `/run_job` endpoint
+- **main.py** – FastAPI server exposing `/run_job`, `/data`, and `/data_csv` endpoints
 
 Install dependencies and run the API (CORS middleware is enabled by default):
 
@@ -34,8 +34,9 @@ npm install
 npm start
 ```
 
-The frontend posts the user's prompt to the backend and displays how many
-items were scraped.
+The frontend posts the user's prompt to the backend and displays a table of
+the scraped data once the job completes. A button is also provided to download
+the results as a CSV file.
 
 ## Usage
 

--- a/backend/controller.py
+++ b/backend/controller.py
@@ -7,10 +7,10 @@ from .data_normalizer import normalize_data
 from .storage_manager import store_items
 
 
-def run_job(prompt: str) -> int:
+def run_job(prompt: str) -> tuple[int, list[dict]]:
     task = parse_instruction(prompt)
     urls = analyze_site(task["target"])
     raw_items = scrape_pages(urls, task)
     cleaned_items = [normalize_data(item) for item in raw_items]
     store_items(cleaned_items)
-    return len(cleaned_items)
+    return len(cleaned_items), cleaned_items

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,9 +1,12 @@
 """FastAPI entrypoint."""
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Response
 from pydantic import BaseModel
 
 from .controller import run_job
+from .storage_manager import fetch_items
+import csv
+from io import StringIO
 
 from fastapi.middleware.cors import CORSMiddleware
 
@@ -26,5 +29,25 @@ class JobRequest(BaseModel):
 
 @app.post("/run_job")
 async def run_job_endpoint(req: JobRequest) -> dict:
-    count = run_job(req.prompt)
-    return {"count": count}
+    count, items = run_job(req.prompt)
+    return {"count": count, "items": items}
+
+
+@app.get("/data")
+async def get_data() -> list[dict]:
+    return fetch_items()
+
+
+@app.get("/data_csv")
+async def get_data_csv() -> Response:
+    items = fetch_items()
+    output = StringIO()
+    writer = csv.DictWriter(output, fieldnames=["title", "price"])
+    writer.writeheader()
+    writer.writerows(items)
+    csv_data = output.getvalue()
+    headers = {
+        "Content-Disposition": "attachment; filename=data.csv",
+        "Content-Type": "text/csv",
+    }
+    return Response(content=csv_data, media_type="text/csv", headers=headers)

--- a/backend/storage_manager.py
+++ b/backend/storage_manager.py
@@ -24,3 +24,13 @@ def store_items(items: list[dict]) -> None:
         )
     conn.commit()
     conn.close()
+
+
+def fetch_items() -> list[dict]:
+    """Return all scraped items from the database."""
+    conn = sqlite3.connect(DB_PATH)
+    cur = conn.cursor()
+    cur.execute("SELECT title, price FROM scraped_data")
+    rows = cur.fetchall()
+    conn.close()
+    return [{"title": row[0], "price": row[1]} for row in rows]

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -5,6 +5,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Scraper Frontend</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
 </head>
 <body>
   <div id="root"></div>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 export default function App() {
   const [prompt, setPrompt] = useState('');
   const [status, setStatus] = useState('');
+  const [items, setItems] = useState([]);
 
   const handleSubmit = async () => {
     setStatus('Running...');
@@ -14,13 +15,38 @@ export default function App() {
     });
     const data = await res.json();
     setStatus(`Completed: ${data.count} items scraped`);
+    setItems(data.items || []);
   };
 
   return (
-    <div>
-      <textarea value={prompt} onChange={(e) => setPrompt(e.target.value)} />
-      <button onClick={handleSubmit}>Run</button>
+    <div className="container py-4">
+      <h1 className="mb-4">Multi-Agent Scraper</h1>
+      <div className="mb-3">
+        <textarea className="form-control" rows="3" value={prompt} onChange={(e) => setPrompt(e.target.value)} />
+      </div>
+      <button className="btn btn-primary mb-3" onClick={handleSubmit}>Run</button>
       <p>{status}</p>
+      {items.length > 0 && (
+        <>
+          <table className="table table-striped">
+            <thead>
+              <tr>
+                <th>Title</th>
+                <th>Price</th>
+              </tr>
+            </thead>
+            <tbody>
+              {items.map((item, idx) => (
+                <tr key={idx}>
+                  <td>{item.title}</td>
+                  <td>{item.price}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          <a className="btn btn-secondary" href="http://localhost:8000/data_csv">Download CSV</a>
+        </>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- return scraped items from backend job
- expose endpoints to fetch data and export CSV
- show table of scraped results with option to download CSV
- style frontend with Bootstrap

## Testing
- `npm install`
- `npm run build`
- `python -m py_compile backend/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6889d8fb4974833284471a353c271d1c